### PR TITLE
Fix wrong Slider tag usage

### DIFF
--- a/Templates/ClassicTools/Classic Tools;Color Balance.lzt
+++ b/Templates/ClassicTools/Classic Tools;Color Balance.lzt
@@ -4,10 +4,7 @@
   <Controls>
     <GenericOperation Active="true" Collapsed="false" Locked="false" Mode="Normal" Name="Classic Color Balance" Opacity="100" OperationType="Color Balance" layerControlsIndex="0" regionsInverted="false">
       <ColorSelection HueBlue="0.5" HueEnabled="true" HueGreen="0.5" HueRadius="-1.0" HueRed="0.5" Inverted="false" LuminosityEnabled="true" LuminosityLower="0.0" LuminosityLowerFeather="0.0" LuminosityUpper="1.0" LuminosityUpperFeather="0.0"/>
-	  <Slider Cyan-Red="0.0"/>
-	  <Slider Magenta-Green="0.0"/>
-	  <Slider Yellow-Blue="0.0"/>
-      <Slider Midpoint="0.18"/>
+      <Slider Cyan-Red="0.0" Magenta-Green="0.0" Yellow-Blue="0.0" Midpoint="0.18"/>
       <Checkbox/>
       <Choice/>
       <Color b="128" g="128" r="128"/>


### PR DESCRIPTION
This change will fix 'Expected attribute "Yellow-Blue" under "Slider"' warning. See http://lightzoneproject.org/lorum/older-styles-wont-work for more detail.